### PR TITLE
re_rar_set: Avoid buffer overread and probably fix big-endian bug

### DIFF
--- a/if_re.c
+++ b/if_re.c
@@ -1638,7 +1638,7 @@ static void re_rar_set(struct re_softc *sc, u_int8_t *eaddr)
         CSR_WRITE_4(sc, RE_IDR0,
                     htole32(*(u_int32_t *)(&eaddr[0])));
         CSR_WRITE_2(sc, RE_IDR4,
-                    htole16(*(u_int32_t *)(&eaddr[4])));
+                    htole16(*(u_int16_t *)(&eaddr[4])));
 
         switch (sc->re_type) {
         case MACFG_36:


### PR DESCRIPTION
eaddr is a byte buffer of length ETHER_ADDR_LEN, i.e. 6 bytes, so we shouldn't try to read bytes at offset 6 and 7. This also looks like it will end up using the wrong half of the word (the two following bytes) on big-endian systems. Fix this by just reading 2 bytes, as is done below for some of the other CSRs.